### PR TITLE
Fix: use correct rstrip syntax to get str output

### DIFF
--- a/eos_download.py
+++ b/eos_download.py
@@ -469,8 +469,8 @@ if eve:
    if ztp:
       eos_folder_name+="-noztp"
 
-   os.system("mkdir -p /opt/unetlab/addons/qemu/" + eos_folder_name.rstrip)
-   os.system("mv hda.qcow2 /opt/unetlab/addons/qemu/" + eos_folder_name.rstrip)
+   os.system("mkdir -p /opt/unetlab/addons/qemu/" + eos_folder_name.rstrip())
+   os.system("mv hda.qcow2 /opt/unetlab/addons/qemu/" + eos_folder_name.rstrip())
    os.system("/opt/unetlab/wrappers/unl_wrapper -a fixpermissions")
    os.system("rm "+ eos_filename)
    print ("Image successfully created")


### PR DESCRIPTION
Fix issue #8

Update rstrip to output a `string` instead of `<built-in method rstrip of str object at 0x7f4b0053b9c0>`