### PR TITLE
Update EOS regular expression to match more versions

### DIFF
--- a/eos_download.py
+++ b/eos_download.py
@@ -223,7 +223,7 @@ def check_arguments(api, file_list, img, cvp, rootpw, cvp_user, cvp_passwd, eve,
       elif image == 'alertbase':
          return True
       elif img == ('INT') or img == ('64') or img == ('2GB') or img == ('2GB-INT') or img == ('vEOS') or img == ('vEOS-lab') or img == ('vEOS-lab-swi') or img == ('vEOS64-lab') or img == ('cEOS') or img == ('cEOS64') or img == ('RN') or img == ('source') or img == (''):
-         test = re.compile('^[0-9]\\.[0-9][0-9]\\.[0-9]\\.*[0-9]*[F|M]$')
+         test = re.compile('^[0-9]{1,}\\.[0-9]{1,}\\.[0-9]{1,}(\\.[0-9]{1,})*[F|M]$')
          eos_valid = test.match(image)
          if image == 'latest':
             eos_valid = True

--- a/eos_download_light.py
+++ b/eos_download_light.py
@@ -215,7 +215,7 @@ def check_arguments(
             or img == ("source")
             or img == ("")
         ):
-            test = re.compile("^[0-9]\\.[0-9][0-9]\\.[0-9]\\.*[0-9]*[F|M]$")
+            test = re.compile("^[0-9]{1,}\\.[0-9]{1,}\\.[0-9]{1,}(\\.[0-9]{1,})*[F|M]$")
             eos_valid = test.match(image)
             if image == "latest":
                 eos_valid = True


### PR DESCRIPTION
The current one won't match versions such as `4.28.10.1M` as the 3rd number is more than 1 digit.
I updated it to be are more flexible and match more possible versions.